### PR TITLE
Lower minSdkVersion to 14

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 4
         versionName "1.2.0"

--- a/library/src/main/res/values-v16/fonts.xml
+++ b/library/src/main/res/values-v16/fonts.xml
@@ -2,6 +2,7 @@
 <resources>
     <style name="Font.Button" parent="Base.TextAppearance.AppCompat.Button">
         <item name="android:textSize">14sp</item>
+        <item name="android:fontFamily">sans-serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 </resources>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.doodle.android.chips.sample"
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 3
         versionName "1.2.0"


### PR DESCRIPTION
Fixes #18  
This did require not using fontFamily on API 14, so the font will be the default serif font, but at least it works.